### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <img src="https://raw.github.com/biovisualize/micropolar/gh-pages/micropolar_black.png" width="250"/><br />
 
-#micropolar
+# micropolar
 A tiny polar charts library made with D3.js for [Plotly](https://plot.ly/). See it in action [here](http://micropolar.org/).
 
 Every chart is composed of a very configurable axis and one or more geometry modules. The current chart types are linePlot, dotPlot, barChart and areaChart. 
 
-##Roadmap
+## Roadmap
 * <s>Minified version</s>
 * <s>Multiple geometry per axis</s>
 * <s>Titles, legends</s>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
